### PR TITLE
IN-142 - response formats

### DIFF
--- a/docs/deputy-reporting-openapi-v1.yml
+++ b/docs/deputy-reporting-openapi-v1.yml
@@ -118,8 +118,8 @@ paths:
                 properties:
                   data:
                     $ref: '#/components/schemas/Healthcheck'
-                  links:
-                    type: object
+#                  links:
+#                    type: object
                   meta:
                     type: object
         400:
@@ -209,17 +209,16 @@ paths:
                 type: object
                 required:
                   - data
-                  - links
                 properties:
                   data:
-                    $ref: '#/components/schemas/Report'
-                  links:
-                    type: object
-                    properties:
-                      api-docs:
-                        type: string
-                        format: uri
-                        example: "https://opg-data-api.service.gov.uk/developer/"
+                    $ref: '#/components/schemas/Response201'
+#                  links:
+#                    type: object
+#                    properties:
+#                      api-docs:
+#                        type: string
+#                        format: uri
+#                        example: "https://opg-data-api.service.gov.uk/developer/"
                   meta:
                     type: object
         400:
@@ -327,17 +326,17 @@ paths:
                 type: object
                 required:
                   - data
-                  - links
+#                  - links
                 properties:
                   data:
-                    $ref: '#/components/schemas/ReportSupportingDocument'
-                  links:
-                    type: object
-                    properties:
-                      api-docs:
-                        type: string
-                        format: uri
-                        example: "https://opg-data-api.service.gov.uk/developer/"
+                    $ref: '#/components/schemas/Response201'
+#                  links:
+#                    type: object
+#                    properties:
+#                      api-docs:
+#                        type: string
+#                        format: uri
+#                        example: "https://opg-data-api.service.gov.uk/developer/"
                   meta:
                     type: object
         400:
@@ -451,20 +450,20 @@ components:
               example: "PF"
         file:
           $ref: '#/components/schemas/file'
-        links:
-          type: object
-          readOnly: true
-          required:
-            - self
-          properties:
-            self:
-              type: string
-              format: uri
-              example: "https://opg-data-api.service.gov.uk/reports/5a8b1a26-8296-4373-ae61-f8d0b250e773"
-            client:
-              type: string
-              format: uri
-              example: "https://opg-data-api.service.gov.uk/clients/0319392T"
+#        links:
+#          type: object
+#          readOnly: true
+#          required:
+#            - self
+#          properties:
+#            self:
+#              type: string
+#              format: uri
+#              example: "https://opg-data-api.service.gov.uk/reports/5a8b1a26-8296-4373-ae61-f8d0b250e773"
+#            client:
+#              type: string
+#              format: uri
+#              example: "https://opg-data-api.service.gov.uk/clients/0319392T"
     ReportSupportingDocument:
       type: object
       required:
@@ -487,20 +486,20 @@ components:
               $ref: '#/components/schemas/submissionId'
         file:
           $ref: '#/components/schemas/file'
-        links:
-          type: object
-          readOnly: true
-          required:
-            - self
-          properties:
-            self:
-              type: string
-              format: uri
-              example: 'https://opg-data-api.service.gov.uk/reports/5a8b1a26-8296-4373-ae61-f8d0b250e773/supportingdocuments/5a8b1a26-8296-4373-ae61-f8d0b250e774'
-            report:
-              type: string
-              format: uri
-              example: 'https://opg-data-api.service.gov.uk/reports/5a8b1a26-8296-4373-ae61-f8d0b250e773'
+#        links:
+#          type: object
+#          readOnly: true
+#          required:
+#            - self
+#          properties:
+#            self:
+#              type: string
+#              format: uri
+#              example: 'https://opg-data-api.service.gov.uk/reports/5a8b1a26-8296-4373-ae61-f8d0b250e773/supportingdocuments/5a8b1a26-8296-4373-ae61-f8d0b250e774'
+#            report:
+#              type: string
+#              format: uri
+#              example: 'https://opg-data-api.service.gov.uk/reports/5a8b1a26-8296-4373-ae61-f8d0b250e773'
     CaseRef:
       type: string
       pattern: '^([0-9]{7}T|[0-9]{8})$'
@@ -533,6 +532,41 @@ components:
           type: string
           format: byte
           description: The base64 encoded file
+    Response201:
+      type: object
+      required:
+        - type
+        - id
+        - attributes
+#        - links
+      properties:
+        type:
+          type: string
+          pattern: "^reports$"
+          example: reports
+        id:
+          $ref: '#/components/schemas/DocumentUuid'
+        attributes:
+          type: object
+          required:
+            - submission_id
+          properties:
+            submission_id:
+              $ref: '#/components/schemas/submissionId'
+#        links:
+#          type: object
+#          readOnly: true
+#          required:
+#            - self
+#          properties:
+#            self:
+#              type: string
+#              format: uri
+#              example: "https://opg-data-api.service.gov.uk/reports/5a8b1a26-8296-4373-ae61-f8d0b250e773"
+#            client:
+#              type: string
+#              format: uri
+#              example: "https://opg-data-api.service.gov.uk/clients/1234567T"
     Error400:
       type: object
       required:
@@ -558,13 +592,13 @@ components:
               detail:
                 type: string
                 example: "Invalid request, the data is incorrect"
-              links:
-                type: object
-                properties:
-                  about:
-                    type: string
-                    format: uri
-                    example: "https://opg-data-api.service.gov.uk/help/errors/invalidrequest"
+#              links:
+#                type: object
+#                properties:
+#                  about:
+#                    type: string
+#                    format: uri
+#                    example: "https://opg-data-api.service.gov.uk/help/errors/invalidrequest"
               source:
                 type: object
                 properties:
@@ -599,13 +633,13 @@ components:
               detail:
                 type: string
                 example: "Unauthorised (no current user and there should be)"
-              links:
-                type: object
-                properties:
-                  about:
-                    type: string
-                    format: uri
-                    example: "https://opg-data-api.service.gov.uk/help/errors/unauthorised"
+#              links:
+#                type: object
+#                properties:
+#                  about:
+#                    type: string
+#                    format: uri
+#                    example: "https://opg-data-api.service.gov.uk/help/errors/unauthorised"
               source:
                 type: object
                 properties:
@@ -640,13 +674,13 @@ components:
               detail:
                 type: string
                 example: "Forbidden - The current user is forbidden from accessing this data (in this way)"
-              links:
-                type: object
-                properties:
-                  about:
-                    type: string
-                    format: uri
-                    example: "https://opg-data-api.service.gov.uk/help/errors/forbidden"
+#              links:
+#                type: object
+#                properties:
+#                  about:
+#                    type: string
+#                    format: uri
+#                    example: "https://opg-data-api.service.gov.uk/help/errors/forbidden"
               source:
                 type: object
                 properties:
@@ -681,13 +715,13 @@ components:
               detail:
                 type: string
                 example: "That URL is not a valid route, or the item resource does not exist"
-              links:
-                type: object
-                properties:
-                  about:
-                    type: string
-                    format: uri
-                    example: "https://opg-data-api.service.gov.uk/help/errors/notfound"
+#              links:
+#                type: object
+#                properties:
+#                  about:
+#                    type: string
+#                    format: uri
+#                    example: "https://opg-data-api.service.gov.uk/help/errors/notfound"
               source:
                 type: object
                 properties:
@@ -722,13 +756,13 @@ components:
               detail:
                 type: string
                 example: "Payload too large, try and upload in smaller chunks"
-              links:
-                type: object
-                properties:
-                  about:
-                    type: string
-                    format: uri
-                    example: "https://opg-data-api.service.gov.uk/help/errors/filesizelimit"
+#              links:
+#                type: object
+#                properties:
+#                  about:
+#                    type: string
+#                    format: uri
+#                    example: "https://opg-data-api.service.gov.uk/help/errors/filesizelimit"
               source:
                 type: object
                 properties:
@@ -763,13 +797,13 @@ components:
               detail:
                 type: string
                 example: "Unsupported media type for this endpoint"
-              links:
-                type: object
-                properties:
-                  about:
-                    type: string
-                    format: uri
-                    example: "https://opg-data-api.service.gov.uk/help/errors/unsupportedtype"
+#              links:
+#                type: object
+#                properties:
+#                  about:
+#                    type: string
+#                    format: uri
+#                    example: "https://opg-data-api.service.gov.uk/help/errors/unsupportedtype"
               source:
                 type: object
                 properties:
@@ -804,13 +838,13 @@ components:
               detail:
                 type: string
                 example: "Something unexpected happened internally"
-              links:
-                type: object
-                properties:
-                  about:
-                    type: string
-                    format: uri
-                    example: "https://opg-data-api.service.gov.uk/help/errors/servererror"
+#              links:
+#                type: object
+#                properties:
+#                  about:
+#                    type: string
+#                    format: uri
+#                    example: "https://opg-data-api.service.gov.uk/help/errors/servererror"
               source:
                 type: object
                 properties:
@@ -845,13 +879,13 @@ components:
               detail:
                 type: string
                 example: "Service is currently unavailable. Please try again later"
-              links:
-                type: object
-                properties:
-                  about:
-                    type: string
-                    format: uri
-                    example: "https://opg-data-api.service.gov.uk/help/errors/unavailable"
+#              links:
+#                type: object
+#                properties:
+#                  about:
+#                    type: string
+#                    format: uri
+#                    example: "https://opg-data-api.service.gov.uk/help/errors/unavailable"
               source:
                 type: object
                 properties:

--- a/docs/deputy-reporting-openapi-v1.yml
+++ b/docs/deputy-reporting-openapi-v1.yml
@@ -25,67 +25,67 @@ x-amazon-apigateway-request-validators:
 x-amazon-apigateway-gateway-responses:
   ACCESS_DENIED:
       responseTemplates:
-        application/json: '{ "id": $context.requestId, "code": "OPGDATA-API-FORBIDDEN", "title":$context.error.messageString, "detail":"Forbidden - The current user is forbidden from accessing this data (in this way)" }'
+        application/json: '{"errors": { "id": "$context.requestId", "code": "OPGDATA-API-FORBIDDEN", "title":$context.error.messageString, "detail":"Forbidden - The current user is forbidden from accessing this data (in this way)", "meta": {"x-ray": "$context.xrayTraceId"} }}'
   API_CONFIGURATION_ERROR:
       responseTemplates:
-        application/json: '{ "id": $context.requestId, "code": "OPGDATA-API-API_CONFIGURATION_ERROR", "title":$context.error.messageString}'
+        application/json: '{"errors": { "id": "$context.requestId", "code": "OPGDATA-API-API_CONFIGURATION_ERROR", "title":$context.error.messageString, "detail": "", "meta": {"x-ray": "$context.xrayTraceId"} }}'
   AUTHORIZER_CONFIGURATION_ERROR:
       responseTemplates:
-        application/json: '{ "id": $context.requestId, "code": "OPGDATA-API-AUTHORIZER_CONFIGURATION_ERROR", "title":$context.error.messageString}'
+        application/json: '{"errors": { "id": "$context.requestId", "code": "OPGDATA-API-AUTHORIZER_CONFIGURATION_ERROR", "title":$context.error.messageString, "detail": "", "meta": {"x-ray": "$context.xrayTraceId"} }}'
   AUTHORIZER_FAILURE:
       responseTemplates:
-        application/json: '{ "id": $context.requestId, "code": "OPGDATA-API-AUTHORIZER_FAILURE", "title":$context.error.messageString}'
+        application/json: '{"errors": { "id": "$context.requestId", "code": "OPGDATA-API-AUTHORIZER_FAILURE", "title":$context.error.messageString, "detail": "", "meta": {"x-ray": "$context.xrayTraceId"} }}'
   BAD_REQUEST_BODY:
       responseTemplates:
-        application/json: '{ "id": $context.requestId, "code": "OPGDATA-API-INVALIDREQUEST", "title":$context.error.messageString, "detail":$context.error.validationErrorString }'
+        application/json: '{"errors": [{ "id": "$context.requestId", "code": "OPGDATA-API-INVALIDREQUEST", "title":$context.error.messageString, "detail":"$context.error.validationErrorString", "meta": {"x-ray": "$context.xrayTraceId"} }]}'
   BAD_REQUEST_PARAMETERS:
       responseTemplates:
-        application/json: '{ "id": $context.requestId, "code": "OPGDATA-API-BAD_REQUEST_PARAMETERS", "title":$context.error.messageString}'
+        application/json: '{"errors": { "id": "$context.requestId", "code": "OPGDATA-API-BAD_REQUEST_PARAMETERS", "title":$context.error.messageString, "detail": "", "meta": {"x-ray": "$context.xrayTraceId"} }}'
   DEFAULT_4XX:
       responseTemplates:
-        application/json: '{ "id": $context.requestId, "code": "OPGDATA-API-INVALIDREQUEST", "title":$context.error.messageString}'
+        application/json: '{"errors": { "id": "$context.requestId", "code": "OPGDATA-API-INVALIDREQUEST", "title":$context.error.messageString, "detail": "", "meta": {"x-ray": "$context.xrayTraceId"} }}'
   DEFAULT_5XX:
       responseTemplates:
-        application/json: '{ "id": $context.requestId, "code": "OPGDATA-API-SERVERERROR", "title":$context.error.messageString, "detail":"Something unexpected happened internally" }'
+        application/json: '{"errors": { "id": "$context.requestId", "code": "OPGDATA-API-SERVERERROR", "title":$context.error.messageString, "detail":"Something unexpected happened internally", "meta": {"x-ray": "$context.xrayTraceId"} }}'
   EXPIRED_TOKEN:
       responseTemplates:
-        application/json: '{ "id": $context.requestId, "code": "OPGDATA-API-EXPIRED_TOKEN", "title":$context.error.messageString}'
+        application/json: '{"errors": { "id": "$context.requestId", "code": "OPGDATA-API-EXPIRED_TOKEN", "title":$context.error.messageString, "detail": "", "meta": {"x-ray": "$context.xrayTraceId"} }}'
   INTEGRATION_FAILURE:
       responseTemplates:
-        application/json: '{ "id": $context.requestId, "code": "OPGDATA-API-INTEGRATION_FAILURE", "title":$context.error.messageString}'
+        application/json: '{"errors": { "id": "$context.requestId", "code": "OPGDATA-API-INTEGRATION_FAILURE", "title":$context.error.messageString, "detail": "", "meta": {"x-ray": "$context.xrayTraceId"} }}'
   INTEGRATION_TIMEOUT:
       responseTemplates:
-        application/json: '{ "id": $context.requestId, "code": "OPGDATA-API-INTEGRATION_TIMEOUT", "title":$context.error.messageString}'
+        application/json: '{"errors": { "id": "$context.requestId", "code": "OPGDATA-API-INTEGRATION_TIMEOUT", "title":$context.error.messageString, "detail": "", "meta": {"x-ray": "$context.xrayTraceId"} }}'
   INVALID_API_KEY:
       responseTemplates:
-        application/json: '{ "id": $context.requestId, "code": "OPGDATA-API-INVALID_API_KEY", "title":$context.error.messageString}'
+        application/json: '{"errors": { "id": "$context.requestId", "code": "OPGDATA-API-INVALID_API_KEY", "title":$context.error.messageString, "detail": "", "meta": {"x-ray": "$context.xrayTraceId"} }}'
   INVALID_SIGNATURE:
       responseTemplates:
-        application/json: '{ "id": $context.requestId, "code": "OPGDATA-API-INVALID_SIGNATURE", "title":$context.error.messageString}'
+        application/json: '{"errors": { "id": "$context.requestId", "code": "OPGDATA-API-INVALID_SIGNATURE", "title":$context.error.messageString, "detail": "", "meta": {"x-ray": "$context.xrayTraceId"} }}'
   MISSING_AUTHENTICATION_TOKEN:
       responseTemplates:
-        application/json: '{ "id": $context.requestId, "code": "OPGDATA-API-MISSING_AUTHENTICATION_TOKEN", "title":$context.error.messageString}'
+        application/json: '{"errors": { "id": "$context.requestId", "code": "OPGDATA-API-MISSING_AUTHENTICATION_TOKEN", "title":$context.error.messageString, "detail": "", "meta": {"x-ray": "$context.xrayTraceId"} }}'
   QUOTA_EXCEEDED:
       responseTemplates:
-        application/json: '{ "id": $context.requestId, "code": "OPGDATA-API-QUOTA_EXCEEDED", "title":$context.error.messageString}'
+        application/json: '{"errors": { "id": "$context.requestId", "code": "OPGDATA-API-QUOTA_EXCEEDED", "title":$context.error.messageString, "detail": "", "meta": {"x-ray": "$context.xrayTraceId"} }}'
   REQUEST_TOO_LARGE:
       responseTemplates:
-        application/json: '{ "id": $context.requestId, "code": "OPGDATA-API-FILESIZELIMIT", "title":$context.error.messageString, "detail":"Payload too large, try and upload in smaller chunks" }'
+        application/json: '{"errors": { "id": "$context.requestId", "code": "OPGDATA-API-FILESIZELIMIT", "title":$context.error.messageString, "detail":"Payload too large, try and upload in smaller chunks", "meta": {"x-ray": "$context.xrayTraceId"} }}'
   RESOURCE_NOT_FOUND:
       responseTemplates:
-        application/json: '{ "id": $context.requestId, "code": "OPGDATA-API-NOTFOUND", "title":$context.error.messageString, "detail":"That URL is not a valid route, or the item resource does not exist" }'
+        application/json: '{"errors": { "id": "$context.requestId", "code": "OPGDATA-API-NOTFOUND", "title":$context.error.messageString, "detail":"That URL is not a valid route, or the item resource does not exist", "meta": {"x-ray": "$context.xrayTraceId"} }}'
   THROTTLED:
       responseTemplates:
-        application/json: '{ "id": $context.requestId, "code": "OPGDATA-API-THROTTLED", "title":$context.error.messageString}'
+        application/json: '{"errors": { "id": "$context.requestId", "code": "OPGDATA-API-THROTTLED", "title":$context.error.messageString, "detail": "", "meta": {"x-ray": "$context.xrayTraceId"} }}'
   UNAUTHORIZED:
       responseTemplates:
-        application/json: '{ "id": $context.requestId, "code": "OPGDATA-API-UNAUTHORISED", "title":$context.error.messageString, "detail":"Unauthorised (no current user and there should be)" }'
+        application/json: '{"errors": { "id": "$context.requestId", "code": "OPGDATA-API-UNAUTHORISED", "title":$context.error.messageString, "detail":"Unauthorised (no current user and there should be)", "meta": {"x-ray": "$context.xrayTraceId"} }}'
   UNSUPPORTED_MEDIA_TYPE:
       responseTemplates:
-        application/json: '{ "id": $context.requestId, "code": "OPGDATA-API-MEDIA", "title":$context.error.messageString, "detail":"Unsupported media type for this endpoint" }'
+        application/json: '{"errors": { "id": "$context.requestId", "code": "OPGDATA-API-MEDIA", "title":$context.error.messageString, "detail":"Unsupported media type for this endpoint", "meta": {"x-ray": "$context.xrayTraceId"} }}'
   WAF_FILTERED:
       responseTemplates:
-        application/json: '{ "id": $context.requestId, "code": "OPGDATA-API-WAF_FILTERED", "title":$context.error.messageString}'
+        application/json: '{"errors": { "id": "$context.requestId", "code": "OPGDATA-API-WAF_FILTERED", "title":$context.error.messageString, "detail": "", "meta": {"x-ray": "$context.xrayTraceId"} }}'
 
 paths:
   /healthcheck:
@@ -599,15 +599,21 @@ components:
 #                    type: string
 #                    format: uri
 #                    example: "https://opg-data-api.service.gov.uk/help/errors/invalidrequest"
-              source:
+              # source:
+              #   type: object
+              #   properties:
+              #     parameter:
+              #       type: string
+              #       example: "clientref"
+              #     pointer:
+              #       type: string
+              #       example: "/data/attributes/date_submitted"
+              meta:
                 type: object
                 properties:
-                  parameter:
+                  x-ray:
                     type: string
-                    example: "clientref"
-                  pointer:
-                    type: string
-                    example: "/data/attributes/date_submitted"
+                    example: "93c330d4-7d84-4c1b-8fdb-54cec5bfe747"
     Error401:
       type: object
       required:
@@ -640,15 +646,21 @@ components:
 #                    type: string
 #                    format: uri
 #                    example: "https://opg-data-api.service.gov.uk/help/errors/unauthorised"
-              source:
+              # source:
+              #   type: object
+              #   properties:
+              #     parameter:
+              #       type: string
+              #       example: "clientref"
+              #     pointer:
+              #       type: string
+              #       example: "/data/attributes/date_submitted"
+              meta:
                 type: object
                 properties:
-                  parameter:
+                  x-ray:
                     type: string
-                    example: "clientref"
-                  pointer:
-                    type: string
-                    example: "/data/attributes/date_submitted"
+                    example: "93c330d4-7d84-4c1b-8fdb-54cec5bfe747"
     Error403:
       type: object
       required:
@@ -681,15 +693,21 @@ components:
 #                    type: string
 #                    format: uri
 #                    example: "https://opg-data-api.service.gov.uk/help/errors/forbidden"
-              source:
+              # source:
+              #   type: object
+              #   properties:
+              #     parameter:
+              #       type: string
+              #       example: "clientref"
+              #     pointer:
+              #       type: string
+              #       example: "/data/attributes/date_submitted"
+              meta:
                 type: object
                 properties:
-                  parameter:
+                  x-ray:
                     type: string
-                    example: "clientref"
-                  pointer:
-                    type: string
-                    example: "/data/attributes/date_submitted"
+                    example: "93c330d4-7d84-4c1b-8fdb-54cec5bfe747"
     Error404:
       type: object
       required:
@@ -722,15 +740,21 @@ components:
 #                    type: string
 #                    format: uri
 #                    example: "https://opg-data-api.service.gov.uk/help/errors/notfound"
-              source:
+              # source:
+              #   type: object
+              #   properties:
+              #     parameter:
+              #       type: string
+              #       example: "clientref"
+              #     pointer:
+              #       type: string
+              #       example: "/data/attributes/date_submitted"
+              meta:
                 type: object
                 properties:
-                  parameter:
+                  x-ray:
                     type: string
-                    example: "clientref"
-                  pointer:
-                    type: string
-                    example: "/data/attributes/date_submitted"
+                    example: "93c330d4-7d84-4c1b-8fdb-54cec5bfe747"
     Error413:
       type: object
       required:
@@ -763,15 +787,21 @@ components:
 #                    type: string
 #                    format: uri
 #                    example: "https://opg-data-api.service.gov.uk/help/errors/filesizelimit"
-              source:
+              # source:
+              #   type: object
+              #   properties:
+              #     parameter:
+              #       type: string
+              #       example: "clientref"
+              #     pointer:
+              #       type: string
+              #       example: "/data/attributes/date_submitted"
+              meta:
                 type: object
                 properties:
-                  parameter:
+                  x-ray:
                     type: string
-                    example: "clientref"
-                  pointer:
-                    type: string
-                    example: "/data/attributes/date_submitted"
+                    example: "93c330d4-7d84-4c1b-8fdb-54cec5bfe747"
     Error415:
       type: object
       required:
@@ -804,15 +834,21 @@ components:
 #                    type: string
 #                    format: uri
 #                    example: "https://opg-data-api.service.gov.uk/help/errors/unsupportedtype"
-              source:
+              # source:
+              #   type: object
+              #   properties:
+              #     parameter:
+              #       type: string
+              #       example: "clientref"
+              #     pointer:
+              #       type: string
+              #       example: "/data/attributes/date_submitted"
+              meta:
                 type: object
                 properties:
-                  parameter:
+                  x-ray:
                     type: string
-                    example: "clientref"
-                  pointer:
-                    type: string
-                    example: "/data/attributes/date_submitted"
+                    example: "93c330d4-7d84-4c1b-8fdb-54cec5bfe747"
     Error500:
       type: object
       required:
@@ -845,15 +881,21 @@ components:
 #                    type: string
 #                    format: uri
 #                    example: "https://opg-data-api.service.gov.uk/help/errors/servererror"
-              source:
+              # source:
+              #   type: object
+              #   properties:
+              #     parameter:
+              #       type: string
+              #       example: "clientref"
+              #     pointer:
+              #       type: string
+              #       example: "/data/attributes/date_submitted"
+              meta:
                 type: object
                 properties:
-                  parameter:
+                  x-ray:
                     type: string
-                    example: "clientref"
-                  pointer:
-                    type: string
-                    example: "/data/attributes/date_submitted"
+                    example: "93c330d4-7d84-4c1b-8fdb-54cec5bfe747"
     Error503:
       type: object
       required:
@@ -886,12 +928,18 @@ components:
 #                    type: string
 #                    format: uri
 #                    example: "https://opg-data-api.service.gov.uk/help/errors/unavailable"
-              source:
+              # source:
+              #   type: object
+              #   properties:
+              #     parameter:
+              #       type: string
+              #       example: "clientref"
+              #     pointer:
+              #       type: string
+              #       example: "/data/attributes/date_submitted"
+              meta:
                 type: object
                 properties:
-                  parameter:
+                  x-ray:
                     type: string
-                    example: "clientref"
-                  pointer:
-                    type: string
-                    example: "/data/attributes/date_submitted"
+                    example: "93c330d4-7d84-4c1b-8fdb-54cec5bfe747"

--- a/docs/deputy-reporting-openapi-v1.yml
+++ b/docs/deputy-reporting-openapi-v1.yml
@@ -6,8 +6,6 @@ info:
   description: "Access to OPG Data"
   contact:
     name: API Support
-    # url: "http://www.example.com/support"
-    # email: "support@example.com"
 
 servers:
   - url: /v1
@@ -118,8 +116,6 @@ paths:
                 properties:
                   data:
                     $ref: '#/components/schemas/Healthcheck'
-#                  links:
-#                    type: object
                   meta:
                     type: object
         400:
@@ -212,13 +208,6 @@ paths:
                 properties:
                   data:
                     $ref: '#/components/schemas/Response201'
-#                  links:
-#                    type: object
-#                    properties:
-#                      api-docs:
-#                        type: string
-#                        format: uri
-#                        example: "https://opg-data-api.service.gov.uk/developer/"
                   meta:
                     type: object
         400:
@@ -326,17 +315,9 @@ paths:
                 type: object
                 required:
                   - data
-#                  - links
                 properties:
                   data:
                     $ref: '#/components/schemas/Response201'
-#                  links:
-#                    type: object
-#                    properties:
-#                      api-docs:
-#                        type: string
-#                        format: uri
-#                        example: "https://opg-data-api.service.gov.uk/developer/"
                   meta:
                     type: object
         400:
@@ -450,20 +431,6 @@ components:
               example: "PF"
         file:
           $ref: '#/components/schemas/file'
-#        links:
-#          type: object
-#          readOnly: true
-#          required:
-#            - self
-#          properties:
-#            self:
-#              type: string
-#              format: uri
-#              example: "https://opg-data-api.service.gov.uk/reports/5a8b1a26-8296-4373-ae61-f8d0b250e773"
-#            client:
-#              type: string
-#              format: uri
-#              example: "https://opg-data-api.service.gov.uk/clients/0319392T"
     ReportSupportingDocument:
       type: object
       required:
@@ -486,20 +453,6 @@ components:
               $ref: '#/components/schemas/submissionId'
         file:
           $ref: '#/components/schemas/file'
-#        links:
-#          type: object
-#          readOnly: true
-#          required:
-#            - self
-#          properties:
-#            self:
-#              type: string
-#              format: uri
-#              example: 'https://opg-data-api.service.gov.uk/reports/5a8b1a26-8296-4373-ae61-f8d0b250e773/supportingdocuments/5a8b1a26-8296-4373-ae61-f8d0b250e774'
-#            report:
-#              type: string
-#              format: uri
-#              example: 'https://opg-data-api.service.gov.uk/reports/5a8b1a26-8296-4373-ae61-f8d0b250e773'
     CaseRef:
       type: string
       pattern: '^([0-9]{7}T|[0-9]{8})$'
@@ -538,7 +491,6 @@ components:
         - type
         - id
         - attributes
-#        - links
       properties:
         type:
           type: string
@@ -553,20 +505,6 @@ components:
           properties:
             submission_id:
               $ref: '#/components/schemas/submissionId'
-#        links:
-#          type: object
-#          readOnly: true
-#          required:
-#            - self
-#          properties:
-#            self:
-#              type: string
-#              format: uri
-#              example: "https://opg-data-api.service.gov.uk/reports/5a8b1a26-8296-4373-ae61-f8d0b250e773"
-#            client:
-#              type: string
-#              format: uri
-#              example: "https://opg-data-api.service.gov.uk/clients/1234567T"
     Error400:
       type: object
       required:
@@ -592,22 +530,6 @@ components:
               detail:
                 type: string
                 example: "Invalid request, the data is incorrect"
-#              links:
-#                type: object
-#                properties:
-#                  about:
-#                    type: string
-#                    format: uri
-#                    example: "https://opg-data-api.service.gov.uk/help/errors/invalidrequest"
-              # source:
-              #   type: object
-              #   properties:
-              #     parameter:
-              #       type: string
-              #       example: "clientref"
-              #     pointer:
-              #       type: string
-              #       example: "/data/attributes/date_submitted"
               meta:
                 type: object
                 properties:
@@ -639,22 +561,6 @@ components:
               detail:
                 type: string
                 example: "Unauthorised (no current user and there should be)"
-#              links:
-#                type: object
-#                properties:
-#                  about:
-#                    type: string
-#                    format: uri
-#                    example: "https://opg-data-api.service.gov.uk/help/errors/unauthorised"
-              # source:
-              #   type: object
-              #   properties:
-              #     parameter:
-              #       type: string
-              #       example: "clientref"
-              #     pointer:
-              #       type: string
-              #       example: "/data/attributes/date_submitted"
               meta:
                 type: object
                 properties:
@@ -686,22 +592,6 @@ components:
               detail:
                 type: string
                 example: "Forbidden - The current user is forbidden from accessing this data (in this way)"
-#              links:
-#                type: object
-#                properties:
-#                  about:
-#                    type: string
-#                    format: uri
-#                    example: "https://opg-data-api.service.gov.uk/help/errors/forbidden"
-              # source:
-              #   type: object
-              #   properties:
-              #     parameter:
-              #       type: string
-              #       example: "clientref"
-              #     pointer:
-              #       type: string
-              #       example: "/data/attributes/date_submitted"
               meta:
                 type: object
                 properties:
@@ -733,22 +623,6 @@ components:
               detail:
                 type: string
                 example: "That URL is not a valid route, or the item resource does not exist"
-#              links:
-#                type: object
-#                properties:
-#                  about:
-#                    type: string
-#                    format: uri
-#                    example: "https://opg-data-api.service.gov.uk/help/errors/notfound"
-              # source:
-              #   type: object
-              #   properties:
-              #     parameter:
-              #       type: string
-              #       example: "clientref"
-              #     pointer:
-              #       type: string
-              #       example: "/data/attributes/date_submitted"
               meta:
                 type: object
                 properties:
@@ -780,22 +654,6 @@ components:
               detail:
                 type: string
                 example: "Payload too large, try and upload in smaller chunks"
-#              links:
-#                type: object
-#                properties:
-#                  about:
-#                    type: string
-#                    format: uri
-#                    example: "https://opg-data-api.service.gov.uk/help/errors/filesizelimit"
-              # source:
-              #   type: object
-              #   properties:
-              #     parameter:
-              #       type: string
-              #       example: "clientref"
-              #     pointer:
-              #       type: string
-              #       example: "/data/attributes/date_submitted"
               meta:
                 type: object
                 properties:
@@ -827,22 +685,6 @@ components:
               detail:
                 type: string
                 example: "Unsupported media type for this endpoint"
-#              links:
-#                type: object
-#                properties:
-#                  about:
-#                    type: string
-#                    format: uri
-#                    example: "https://opg-data-api.service.gov.uk/help/errors/unsupportedtype"
-              # source:
-              #   type: object
-              #   properties:
-              #     parameter:
-              #       type: string
-              #       example: "clientref"
-              #     pointer:
-              #       type: string
-              #       example: "/data/attributes/date_submitted"
               meta:
                 type: object
                 properties:
@@ -874,22 +716,6 @@ components:
               detail:
                 type: string
                 example: "Something unexpected happened internally"
-#              links:
-#                type: object
-#                properties:
-#                  about:
-#                    type: string
-#                    format: uri
-#                    example: "https://opg-data-api.service.gov.uk/help/errors/servererror"
-              # source:
-              #   type: object
-              #   properties:
-              #     parameter:
-              #       type: string
-              #       example: "clientref"
-              #     pointer:
-              #       type: string
-              #       example: "/data/attributes/date_submitted"
               meta:
                 type: object
                 properties:
@@ -921,22 +747,6 @@ components:
               detail:
                 type: string
                 example: "Service is currently unavailable. Please try again later"
-#              links:
-#                type: object
-#                properties:
-#                  about:
-#                    type: string
-#                    format: uri
-#                    example: "https://opg-data-api.service.gov.uk/help/errors/unavailable"
-              # source:
-              #   type: object
-              #   properties:
-              #     parameter:
-              #       type: string
-              #       example: "clientref"
-              #     pointer:
-              #       type: string
-              #       example: "/data/attributes/date_submitted"
               meta:
                 type: object
                 properties:


### PR DESCRIPTION
Edited 201 to a simpler structure - no longer includes the file in the response

Amended all error responses to something that will work with API-G so it's all still created by the swagger doc, whilst trying to keep in line with the json api spec.

Removed all references to 'links' as none of these actually existed, and we currently have no plans to implement.