### PR TITLE
Fixed regex for 201 response

### DIFF
--- a/docs/deputy-reporting-openapi-v1.yml
+++ b/docs/deputy-reporting-openapi-v1.yml
@@ -494,7 +494,7 @@ components:
       properties:
         type:
           type: string
-          pattern: "^reports$"
+          pattern: "^reports|supportingdocuments$"
           example: reports
         id:
           $ref: '#/components/schemas/DocumentUuid'


### PR DESCRIPTION
201 is identical for both endpoints apart from the 'type'. Amended regex to account for this.