### PR TITLE
In 562 - read only access to code artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # opg-data
 
-Data Infrastructure: Managed by opg-org-infra &amp; Terraform
+Data Infrastructure: Managed by opg-org-infra &amp; Terraform.

--- a/infrastructure/terraform/iam.tf
+++ b/infrastructure/terraform/iam.tf
@@ -38,5 +38,77 @@ resource "aws_iam_role_policy" "lambda" {
   policy = data.aws_iam_policy_document.describe_kms.json
 }
 
+// Code artifact user
 
+resource "aws_iam_role" "code_artifact_access" {
+  count              = terraform.workspace == "development" ? 1 : 0
+  name               = "code-artifact-${local.environment}"
+  assume_role_policy = data.aws_iam_policy_document.code_artifact_assume.json
+}
 
+resource "aws_iam_role_policy" "code_artifact_access" {
+  count  = terraform.workspace == "development" ? 1 : 0
+  name   = "code-artifact-${local.environment}"
+  role   = aws_iam_role.code_artifact_access[0].id
+  policy = data.aws_iam_policy_document.code_artifact_access.json
+}
+
+data "aws_iam_policy_document" "code_artifact_assume" {
+  statement {
+    sid    = "AllowAssumeIdentity"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::631181914621:root"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+data "aws_iam_policy_document" "code_artifact_access" {
+  statement {
+    sid    = "AllowReadCodeArtifact"
+    effect = "Allow"
+
+    actions = [
+      "codeartifact:DescribeDomain",
+      "codeartifact:DescribePackageVersion",
+      "codeartifact:DescribeRepository",
+      "codeartifact:GetAuthorizationToken",
+      "codeartifact:GetDomainPermissionsPolicy",
+      "codeartifact:GetPackageVersionAsset",
+      "codeartifact:GetPackageVersionReadme",
+      "codeartifact:GetRepositoryEndpoint",
+      "codeartifact:GetRepositoryPermissionsPolicy",
+      "codeartifact:ListDomains",
+      "codeartifact:ListPackages",
+      "codeartifact:ListPackageVersionAssets",
+      "codeartifact:ListPackageVersionDependencies",
+      "codeartifact:ListPackageVersions",
+      "codeartifact:ListRepositories",
+      "codeartifact:ListRepositoriesInDomain",
+      "codeartifact:ReadFromRepository",
+      "codeartifact:UpdatePackageVersionsStatus",
+    ]
+
+    resources = [
+      "arn:aws:codeartifact:eu-west-1:${local.account.account_id}:repository/opg-moj*",
+      "arn:aws:codeartifact:eu-west-1:${local.account.account_id}:domain/opg-moj",
+    ]
+  }
+
+  statement {
+    sid    = "AllowStsGetServiceBearerToken"
+    effect = "Allow"
+
+    actions = [
+      "sts:GetServiceBearerToken"
+    ]
+
+    resources = [
+      "arn:aws:sts::${local.account.account_id}:assumed-role/code-artifact*"
+    ]
+  }
+}


### PR DESCRIPTION
## Purpose

Add a user that has very limited read only access to code artifact that can be assumed by anyone with an identity account