### PR TITLE
UML-1192 Allow for 204 responses from Sirius

### DIFF
--- a/shared_code/sirius_service/opg_sirius_service/sirius_handler.py
+++ b/shared_code/sirius_service/opg_sirius_service/sirius_handler.py
@@ -206,6 +206,9 @@ class SiriusService:
 
             elif method == "POST":
                 r = requests.post(url=url, data=data, headers=headers)
+                if r.status_code == 204:
+                    return r.status_code, ""
+
                 return r.status_code, r.json()
             elif method == "GET":
                 r = requests.get(url=url, headers=headers)

--- a/shared_code/sirius_service/tests/conftest.py
+++ b/shared_code/sirius_service/tests/conftest.py
@@ -32,6 +32,7 @@ def patched_get_secret(monkeypatch):
 @pytest.fixture()
 def patched_build_sirius_headers(monkeypatch):
     def mock_headers(*args, **kwargs):
+        print("patched_build_sirius_headers returning mock_headers")
 
         return {
             "Content-Type": args[0] if args[0] else "application/json",


### PR DESCRIPTION
## Purpose

The new Access code letter request endpoint returns  a 204 with no body content. When using the `requests` library an exception is thrown when calling `.json()` on a response that has the 204 code - even though the response was valid the library considers it to be in error. This PR catches the 204 case and solves the issue.

## Checklist

* [x] I have performed a self-review of my own code
* [ ] ~I have added relevant logging with appropriate levels to my code~
* [ ] ~I have updated documentation where relevant~
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
