### PR TITLE
Fix version of pyjwt to 1.7.1 in installation dependencies

### DIFF
--- a/shared_code/sirius_service/setup_sirius_service.py
+++ b/shared_code/sirius_service/setup_sirius_service.py
@@ -19,4 +19,9 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.7",
+    install_requires = [
+        "boto3",
+        "requests-aws4auth==1.0.1",
+        "pyjwt==1.7.1",
+    ]
 )


### PR DESCRIPTION
## Purpose

pyjwt v2 changes the return type of a function we use. Fixing to 1.7.1 in the setup.py file means that projects that use this dependency will take notice of that and not just blindly fail when they use v2.

## Checklist

* [x] I have performed a self-review of my own code
* [ ] ~I have added relevant logging with appropriate levels to my code~
* [ ] ~I have updated documentation where relevant~
* [x] ~I have added tests to prove my work~
* [ ] The product team have tested these changes
