### PR TITLE
SP-947 add timeout to get requests #major

### DIFF
--- a/shared_code/sirius_service/opg_sirius_service/sirius_handler.py
+++ b/shared_code/sirius_service/opg_sirius_service/sirius_handler.py
@@ -24,6 +24,7 @@ class SiriusService:
             self.sirius_base_url = config_params.SIRIUS_BASE_URL
             self.environment = config_params.ENVIRONMENT
             self.session_data = config_params.SESSION_DATA
+            self.request_timeout = config_params.REQUEST_TIMEOUT
             self.request_caching = (
                 config_params.REQUEST_CACHING if cache else "disabled"
             )
@@ -154,7 +155,7 @@ class SiriusService:
     def check_sirius_available(self):
         healthcheck_url = f"{self.sirius_base_url}/api/health-check"
         try:
-            return True if requests.get(url=healthcheck_url).status_code == 200 else False
+            return True if requests.get(url=healthcheck_url,timeout=self.request_timeout).status_code == 200 else False
         except Exception as e:
             logger.error(f"Sirius Unavailable: {e}")
             return False
@@ -212,7 +213,7 @@ class SiriusService:
 
                 return r.status_code, r.json()
             elif method == "GET":
-                r = requests.get(url=url, headers=headers)
+                r = requests.get(url=url, headers=headers, timeout=self.request_timeout)
 
                 return r.status_code, r.json()
             else:

--- a/shared_code/sirius_service/setup.py
+++ b/shared_code/sirius_service/setup.py
@@ -5,7 +5,7 @@ with open("sirius_service.md", "r") as fh:
 
 setuptools.setup(
     name="opg_sirius_service",
-    version="0.1.1",
+    version="2.0.0",
     author="OPG",
     author_email="opg-integrations@digital.justice.gov.uk",
     description="Sirius Service",

--- a/shared_code/sirius_service/tests/default_config.py
+++ b/shared_code/sirius_service/tests/default_config.py
@@ -16,6 +16,7 @@ class SiriusServiceTestConfig:
     REQUEST_CACHING = "enabled"
     REQUEST_CACHING_TTL = 48
     REQUEST_CACHE_NAME = "opg-data-lpa-local"
+    REQUEST_TIMEOUT = 10
     REDIS_URL = "redis://redis:6379"
 
     # specific to local testing


### PR DESCRIPTION
## Purpose

_Add a timeout to GET requests so the lambda fails quicker and handles the timeout gracefully and doesn't pass 5xx errors to calling service_

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
