### PR TITLE
LPAL-550 - Adds sirius 410 response caching to opg-sirius-service

### DIFF
--- a/shared_code/sirius_service/opg_sirius_service/sirius_handler.py
+++ b/shared_code/sirius_service/opg_sirius_service/sirius_handler.py
@@ -178,9 +178,10 @@ class SiriusService:
             logger.info(f"sirius_status_code: {sirius_status_code}")
             logger.info(f"cache_enables: {cache_enabled}")
             logger.info(f"method: {method}")
-            if cache_enabled and method == "GET" and sirius_status_code == 200:
-                logger.info(f"Putting data in cache with key: {key}")
-                self._put_sirius_data_in_cache(key=key, data=sirius_data)
+            if cache_enabled and method == "GET":
+                if sirius_status_code == 200 or sirius_status_code == 410:
+                    logger.info(f"Putting data in cache with key: {key}")
+                    self._put_sirius_data_in_cache(key=key, data=sirius_data)
 
             return sirius_status_code, sirius_data
         else:

--- a/shared_code/sirius_service/opg_sirius_service/sirius_handler.py
+++ b/shared_code/sirius_service/opg_sirius_service/sirius_handler.py
@@ -231,6 +231,7 @@ class SiriusService:
     def _put_sirius_data_in_cache(self, key, data, status):
         logger.info(f"_put_sirius_data_in_cache")
         cache_name = self.request_caching_name
+        cache_ref = f"{cache_name}-{key}"
 
         cache_ttl_in_seconds = self.request_caching_ttl * 60 * 60
 
@@ -238,33 +239,34 @@ class SiriusService:
 
         try:
             self.cache.set(
-                name=f"{cache_name}-{key}-{status}", value=data, ex=cache_ttl_in_seconds
+                name=f"{cache_ref}-{status}", value=data, ex=cache_ttl_in_seconds
             )
-            logger.info(f"setting redis: {cache_name}-{key}-{status}")
+            logger.info(f"setting redis: {cache_ref}-{status}")
         except Exception as e:
-            logger.error(f"Unable to set cache: {cache_name}-{key}-{status}, error {e}")
+            logger.error(f"Unable to set cache: {cache_ref}-{status}, error {e}")
 
     def _get_sirius_data_from_cache(self, key):
 
         cache_name = self.request_caching_name
+        cache_ref = f"{cache_name}-{key}"
 
         try:
-            if self.cache.exists(f"{cache_name}-{key}-200"):
-                logger.info(f"found redis cache: {cache_name}-{key}-200")
+            if self.cache.exists(f"-200"):
+                logger.info(f"found redis cache: {cache_ref}-200")
                 status_code = 200
-                result = self.cache.get(f"{cache_name}-{key}-200")
+                result = self.cache.get(f"{cache_ref}-200")
                 result = json.loads(result)
-            elif self.cache.exists(f"{cache_name}-{key}-410"):
-                logger.info(f"found redis cache: {cache_name}-{key}-410")
+            elif self.cache.exists(f"{cache_ref}-410"):
+                logger.info(f"found redis cache: {cache_ref}-410")
                 status_code = 410
-                result = self.cache.get(f"{cache_name}-{key}-410")
+                result = self.cache.get(f"{cache_ref}-410")
                 result = json.loads(result)
             else:
-                logger.info(f"no-cache exists for: {cache_name}-{key}-[200, 410]")
+                logger.info(f"no-cache exists for: {cache_ref}-[200, 410]")
                 status_code = 500
                 result = None
         except Exception as e:
-            logger.error(f"Unable to get from cache: {cache_name}-{key}, error {e}")
+            logger.error(f"Unable to get from cache: {cache_ref}, error {e}")
             status_code = 500
             result = None
 

--- a/shared_code/sirius_service/opg_sirius_service/sirius_handler.py
+++ b/shared_code/sirius_service/opg_sirius_service/sirius_handler.py
@@ -251,7 +251,7 @@ class SiriusService:
         cache_ref = f"{cache_name}-{key}"
 
         try:
-            if self.cache.exists(f"-200"):
+            if self.cache.exists(f"{cache_ref}-200"):
                 logger.info(f"found redis cache: {cache_ref}-200")
                 status_code = 200
                 result = self.cache.get(f"{cache_ref}-200")

--- a/shared_code/sirius_service/tests/test_get_sirius_data_from_cache.py
+++ b/shared_code/sirius_service/tests/test_get_sirius_data_from_cache.py
@@ -38,6 +38,7 @@ def test_get_sirius_data_from_cache_200(monkeypatch, test_key_name, test_key, te
 
     test_cache.flushall()
 
+@settings(max_examples=max_examples)
 def test_get_sirius_data_from_cache_410(monkeypatch, test_key_name, test_key, test_data):
 
     test_sirius_service.request_caching_name = test_key_name

--- a/shared_code/sirius_service/tests/test_get_sirius_data_from_cache.py
+++ b/shared_code/sirius_service/tests/test_get_sirius_data_from_cache.py
@@ -21,26 +21,36 @@ from .default_config import SiriusServiceTestConfig
     ),
 )
 @settings(max_examples=max_examples)
-@pytest.mark.parametrize(
-    "http_status",
-    [
-        (200),
-        (410)
-    ],
-)
-def test_get_sirius_data_from_cache(monkeypatch, test_key_name, test_key, test_data, http_status):
+def test_get_sirius_data_from_cache_200(monkeypatch, test_key_name, test_key, test_data):
 
     test_sirius_service.request_caching_name = test_key_name
     test_cache = test_sirius_service.cache
 
-    full_key = f"{test_key_name}-{test_key}-{http_status}"
+    full_key = f"{test_key_name}-{test_key}-200"
     test_cache.set(name=full_key, value=json.dumps(test_data))
 
     status_code, result_data = test_sirius_service._get_sirius_data_from_cache(
         key=test_key
     )
 
-    assert status_code == {http_status}
+    assert status_code == 200
+    assert result_data == test_data
+
+    test_cache.flushall()
+
+def test_get_sirius_data_from_cache_410(monkeypatch, test_key_name, test_key, test_data):
+
+    test_sirius_service.request_caching_name = test_key_name
+    test_cache = test_sirius_service.cache
+
+    full_key = f"{test_key_name}-{test_key}-410"
+    test_cache.set(name=full_key, value=json.dumps(test_data))
+
+    status_code, result_data = test_sirius_service._get_sirius_data_from_cache(
+        key=test_key
+    )
+
+    assert status_code == 410
     assert result_data == test_data
 
     test_cache.flushall()

--- a/shared_code/sirius_service/tests/test_get_sirius_data_from_cache.py
+++ b/shared_code/sirius_service/tests/test_get_sirius_data_from_cache.py
@@ -21,19 +21,26 @@ from .default_config import SiriusServiceTestConfig
     ),
 )
 @settings(max_examples=max_examples)
-def test_get_sirius_data_from_cache(monkeypatch, test_key_name, test_key, test_data):
+@pytest.mark.parametrize(
+    "http_status",
+    [
+        (200),
+        (410)
+    ],
+)
+def test_get_sirius_data_from_cache(monkeypatch, test_key_name, test_key, test_data, http_status):
 
     test_sirius_service.request_caching_name = test_key_name
     test_cache = test_sirius_service.cache
 
-    full_key = f"{test_key_name}-{test_key}"
+    full_key = f"{test_key_name}-{test_key}-{http_status}"
     test_cache.set(name=full_key, value=json.dumps(test_data))
 
     status_code, result_data = test_sirius_service._get_sirius_data_from_cache(
         key=test_key
     )
 
-    assert status_code == 200
+    assert status_code == {http_status}
     assert result_data == test_data
 
     test_cache.flushall()

--- a/shared_code/sirius_service/tests/test_put_sirius_data_in_cache.py
+++ b/shared_code/sirius_service/tests/test_put_sirius_data_in_cache.py
@@ -33,7 +33,7 @@ def test_put_sirius_data_in_cache(test_key_name, test_key, test_data, test_ttl):
         key=test_key, data=json.dumps(test_data), status=200
     )
 
-    full_key = f"{test_key_name}-{test_key}"
+    full_key = f"{test_key_name}-{test_key}-200"
 
     assert json.loads(json.loads(test_cache.get(full_key))) == test_data
     assert test_cache.ttl(full_key) == test_ttl * 60 * 60

--- a/shared_code/sirius_service/tests/test_put_sirius_data_in_cache.py
+++ b/shared_code/sirius_service/tests/test_put_sirius_data_in_cache.py
@@ -30,7 +30,7 @@ def test_put_sirius_data_in_cache(test_key_name, test_key, test_data, test_ttl):
     test_sirius_service.request_caching_ttl = test_ttl
 
     test_sirius_service._put_sirius_data_in_cache(
-        key=test_key, data=json.dumps(test_data)
+        key=test_key, data=json.dumps(test_data), status=200
     )
 
     full_key = f"{test_key_name}-{test_key}"
@@ -56,7 +56,7 @@ def test_put_sirius_data_in_cache_broken(caplog):
     )
 
     test_sirius_service._put_sirius_data_in_cache(
-        key=test_key, data=json.dumps(test_data)
+        key=test_key, data=json.dumps(test_data), status="fail"
     )
 
     with caplog.at_level("ERROR"):

--- a/shared_code/sirius_service/tests/test_send_request_to_sirius.py
+++ b/shared_code/sirius_service/tests/test_send_request_to_sirius.py
@@ -76,17 +76,18 @@ def test_send_request_to_sirius(
 
     assert result_status_code == expected_status_code
 
+    cache_key = f"{full_key}-{expected_status_code}"
     if cache_expected:
-        print(f"full_key: {full_key}")
-        print(f"cache.get(full_key): {cache.get(full_key)}")
+        print(f"full_key: {cache_key}")
+        print(f"cache.get(full_key): {cache.get(cache_key)}")
         # print(f"json.loads(cache.get(full_key)): {json.loads(cache.get(full_key))}")
         print(f"cache.scan(): {cache.scan()}")
 
-        assert json.loads(cache.get(full_key)) == sirius_test_data
-        assert cache.ttl(full_key) == ttl * 60 * 60
+        assert json.loads(cache.get(cache_key)) == sirius_test_data
+        assert cache.ttl(cache_key) == ttl * 60 * 60
 
     else:
-        assert cache.exists(full_key) == 0
+        assert cache.exists(cache_key) == 0
 
     cache.flushall()
 
@@ -119,13 +120,15 @@ def test_send_request_to_sirius_request_fails(
     )
 
     assert result_status_code == expected_status_code
+
+    cache_key = f"{full_key}-{expected_status_code}"
     if cache_expected:
 
-        assert json.loads(cache.get(full_key)) == json.loads(sirius_test_data)
-        assert cache.ttl(full_key) == ttl * 60 * 60
+        assert json.loads(cache.get(cache_key)) == json.loads(sirius_test_data)
+        assert cache.ttl(cache_key) == ttl * 60 * 60
 
     else:
-        assert cache.exists(full_key) == 0
+        assert cache.exists(cache_key) == 0
     cache.flushall()
 
 
@@ -161,11 +164,13 @@ def test_send_request_to_sirius_but_sirius_is_broken_value_in_cache(
     )
 
     assert result_status_code == expected_status_code
-    if cache_expected:
-        print(f"json.loads(cache.get(full_key)): {json.loads(cache.get(full_key))}")
 
-        assert json.loads(cache.get(full_key)) == json.loads(sirius_test_data)
-        assert cache.ttl(full_key) == ttl * 60 * 60
+    cache_key = f"{full_key}-{expected_status_code}"
+    if cache_expected:
+        print(f"json.loads(cache.get(cache_key)): {json.loads(cache.get(cache_key))}")
+
+        assert json.loads(cache.get(cache_key)) == json.loads(sirius_test_data)
+        assert cache.ttl(cache_key) == ttl * 60 * 60
 
     cache.flushall()
 
@@ -198,12 +203,14 @@ def test_send_request_to_sirius_but_sirius_is_broken_value_not_in_cache(
     )
 
     assert result_status_code == expected_status_code
+
+    cache_key = f"{full_key}-{expected_status_code}"
     if cache_expected:
 
-        assert json.loads(cache.get(full_key)) == sirius_test_data
-        assert cache.ttl(full_key) == ttl * 60 * 60
+        assert json.loads(cache.get(cache_key)) == sirius_test_data
+        assert cache.ttl(cache_key) == ttl * 60 * 60
 
     else:
-        assert cache.exists(full_key) == 0
+        assert cache.exists(cache_key) == 0
 
     cache.flushall()

--- a/shared_code/sirius_service/tests/test_send_request_to_sirius.py
+++ b/shared_code/sirius_service/tests/test_send_request_to_sirius.py
@@ -49,9 +49,11 @@ def mock_get_data_from_sirius_failed(monkeypatch):
     "method, cache_enabled, expected_status_code, cache_expected",
     [
         ("GET", "enabled", 200, True),
+        ("GET", "enabled", 410, True),
         ("POST", "enabled", 200, False),
         ("PUT", "enabled", 200, False),
         ("GET", "disabled", 200, False),
+        ("GET", "disabled", 410, True),
         ("POST", "disabled", 200, False),
         ("PUT", "disabled", 200, False),
         ("GET", "banana", 200, False),
@@ -136,6 +138,7 @@ def test_send_request_to_sirius_request_fails(
     "method, cache_enabled, expected_status_code, cache_expected",
     [
         ("GET", "enabled", 200, True),
+        ("GET", "enabled", 410, True),
         ("POST", "enabled", 500, False),
         ("PUT", "enabled", 500, False),
         ("GET", "disabled", 500, False),
@@ -153,8 +156,9 @@ def test_send_request_to_sirius_but_sirius_is_broken_value_in_cache(
     expected_status_code,
     cache_expected,
 ):
+    cache_key = f"{full_key}-{expected_status_code}"
 
-    cache.set(name=f"{full_key}", value=sirius_test_data, ex=ttl * 60 * 60)
+    cache.set(name=f"{cache_key}", value=sirius_test_data, ex=ttl * 60 * 60)
     print(f"cache.scan(): {cache.scan()}")
 
     test_sirius_service.request_caching = cache_enabled
@@ -165,7 +169,6 @@ def test_send_request_to_sirius_but_sirius_is_broken_value_in_cache(
 
     assert result_status_code == expected_status_code
 
-    cache_key = f"{full_key}-{expected_status_code}"
     if cache_expected:
         print(f"json.loads(cache.get(cache_key)): {json.loads(cache.get(cache_key))}")
 


### PR DESCRIPTION
## Purpose

Adds handling for 410 response from Sirius, so that it is cached as other 200 responses are.
This is required for further changes to the opg-data-lpa repo, so this service can also correctly handle 410 responses.

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
