### PR TITLE
UML-2747 fix opg-data broken builds

### DIFF
--- a/shared_code/pact/opg_pact/check_pact_deployable.py
+++ b/shared_code/pact/opg_pact/check_pact_deployable.py
@@ -7,7 +7,6 @@ import re
 import os
 import urllib.parse
 from boto3 import Session
-from boto3 import exceptions
 
 
 class PactDeploymentCheck:
@@ -442,11 +441,10 @@ class PactDeploymentCheck:
         )
 
         client = session.client(service_name="secretsmanager", region_name=region_name)
-
         try:
             get_secret_value_response = client.get_secret_value(SecretId=secret_name)
             secret = get_secret_value_response["SecretString"]
-        except exceptions.ClientError as e:
+        except Exception as e:
             print("Unable to get secret from Secrets Manager")
             raise e
 

--- a/shared_code/pact/opg_pact/consumer_pact_check.py
+++ b/shared_code/pact/opg_pact/consumer_pact_check.py
@@ -4,7 +4,6 @@ import re
 import os
 import argparse
 from boto3 import Session
-from boto3 import exceptions
 
 
 class PactDeploymentCheck:
@@ -111,7 +110,7 @@ class PactDeploymentCheck:
                 SecretId=self.broker_secret_name
             )
             secret = get_secret_value_response["SecretString"]
-        except exceptions.ClientError as e:
+        except Exception as e:
             print("Unable to get secret from Secrets Manager")
             raise e
 

--- a/shared_code/pact/opg_pact/requirements.txt
+++ b/shared_code/pact/opg_pact/requirements.txt
@@ -1,3 +1,3 @@
-boto3
-pytest
-moto
+boto3==1.26.13
+pytest==7.2.0
+moto==4.0.10

--- a/shared_code/pact/opg_pact/tag_pact.py
+++ b/shared_code/pact/opg_pact/tag_pact.py
@@ -105,7 +105,7 @@ class PactTagPacticipant:
                 SecretId=self.broker_secret_name
             )
             secret = get_secret_value_response["SecretString"]
-        except exceptions.ClientError as e:
+        except Exception as e:
             print("Unable to get secret from Secrets Manager")
             raise e
 

--- a/shared_code/pact/opg_pact/tests/test_get_secrets.py
+++ b/shared_code/pact/opg_pact/tests/test_get_secrets.py
@@ -1,4 +1,5 @@
 import pytest
+from _pytest.main import Session
 
 from pact_provider.check_pact_deployable import PactDeploymentCheck
 
@@ -14,7 +15,20 @@ from moto import mock_secretsmanager, mock_sts
 @mock_secretsmanager
 @mock_sts
 def test_get_secret(secret_code, environment, region):
-    session = boto3.session.Session()
+    client = boto3.client("sts")
+    account_id = client.get_caller_identity()["Account"]
+    print(account_id)
+
+    role_to_assume = "arn:aws:iam::997462338508:role/get-pact-secret-production"
+    response = client.assume_role(
+        RoleArn=role_to_assume, RoleSessionName="assumed_role"
+    )
+
+    session = boto3.Session(
+        aws_access_key_id=response["Credentials"]["AccessKeyId"],
+        aws_secret_access_key=response["Credentials"]["SecretAccessKey"],
+        aws_session_token=response["Credentials"]["SessionToken"],
+    )
     client = session.client(service_name="secretsmanager", region_name=region)
 
     client.create_secret(Name="pactbroker_admin", SecretString=secret_code)

--- a/shared_code/sirius_service/opg_sirius_service/requirements.txt
+++ b/shared_code/sirius_service/opg_sirius_service/requirements.txt
@@ -1,4 +1,4 @@
-boto3
+boto3==1.26.13
 requests-aws4auth==1.0.1
 moto==1.3.16
 pyjwt==1.7.1
@@ -8,3 +8,4 @@ yarl==1.6.2
 localstack-client==1.5
 fakeredis==1.4.4
 pytest==6.1.1
+importlib-metadata==4.13.0


### PR DESCRIPTION
## Purpose

Fix the builds

## Approach

Moto wasn't pinned and later versions seem to be cleverer with assume roles which was breaking a test. I have made the exception naked exceptions which I wouldn't normally do for an app but for this little pipeline utility that uses AWS exceptions, this isn't used that much and having the specific ones wasn't very helpful for debugging. 

Had to import and pin importlib-metadata for sirius service as that was also breaking things further down the line.

## Learning

NA

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
