### PR TITLE
Fix path to live workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,10 +84,10 @@ jobs:
       run: |
         python -m pip install --user --upgrade setuptools wheel twine
 
-    - name: package shared circleci
-      working-directory: ./shared_code/circle
-      run: |
-        python setup.py sdist bdist_wheel
+    # - name: package shared circleci
+    #   working-directory: ./shared_code/circle
+    #   run: |
+    #     python setup.py sdist bdist_wheel
 
     - name: package shared pact
       working-directory: ./shared_code/pact

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,9 +25,16 @@ jobs:
           - tf_workspace: "production"
     steps:
       - uses: actions/checkout@v2
-      - uses: hashicorp/setup-terraform@v1
+      - name: "Set terraform version [${{ matrix.tf_workspace }}]"
+        id: set-terraform-version
+        uses: ministryofjustice/opg-github-actions/.github/actions/terraform-version@ea1e81f43e7593acd74cc114085930f5f54914a2 # v3.1.7
         with:
-          terraform_version: 1.0.0
+          terraform_directory: ./infrastructure/terraform
+
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_version: ${{ steps.set-terraform-version.outputs.version }}
+
       - name: Configure AWS Credentials For Terraform
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -97,10 +104,10 @@ jobs:
         echo -e "username = __token__" >> ~/.pypirc
         echo -e "password = ${{ secrets.PYPI_TOKEN }}" >> ~/.pypirc
 
-    - name: upload shared circleci
-      working-directory: ./shared_code/circle
-      run: |
-        python -m twine upload dist/* --skip-existing
+    # - name: upload shared circleci
+    #   working-directory: ./shared_code/circle
+    #   run: |
+    #     python -m twine upload dist/* --skip-existing
 
     - name: upload shared pact
       working-directory: ./shared_code/pact


### PR DESCRIPTION
## Purpose

Path to live fails to upload circleci shared code, but we don't use circleci any more and no longer require the code

## Approach

- don't package and upload circleci shared code
- fix setting up terraform version on deploy workflow

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered_
