### PR TITLE
 LPAL-1973b | trivy remediation - adding vars for oidc roles

### DIFF
--- a/infrastructure/terraform/iam.tf
+++ b/infrastructure/terraform/iam.tf
@@ -2,6 +2,22 @@ data "aws_kms_key" "sirius" {
   key_id = "alias/public_api_bucket_${local.account.serve_bucket_suffix}"
 }
 
+locals {
+  identity = var.identity_account_id
+
+  oidc_development_role_arn   = "arn:aws:iam::${local.identity}:role/oidc-serve-development"
+  oidc_preproduction_role_arn = "arn:aws:iam::${local.identity}:role/oidc-serve-preproduction"
+  oidc_production_role_arn    = "arn:aws:iam::${local.identity}:role/oidc-serve-production"
+
+  ci_config = {
+    trusted_oidc_role_arns = [
+      local.oidc_development_role_arn,
+      local.oidc_preproduction_role_arn,
+      local.oidc_production_role_arn,
+    ]
+  }
+}
+
 resource "aws_iam_role" "serve_integration" {
   name               = "serve-assume-role-ci-${local.environment}"
   assume_role_policy = data.aws_iam_policy_document.serve_ci_sirius.json
@@ -13,12 +29,8 @@ data "aws_iam_policy_document" "serve_ci_sirius" {
     effect = "Allow"
 
     principals {
-      type = "AWS"
-      identifiers = [
-        "arn:aws:iam::631181914621:role/oidc-serve-development",
-        "arn:aws:iam::631181914621:role/oidc-serve-preproduction",
-        "arn:aws:iam::631181914621:role/oidc-serve-production"
-      ]
+      type        = "AWS"
+      identifiers = local.ci_config.trusted_oidc_role_arns
     }
 
     actions = ["sts:AssumeRole"]
@@ -64,7 +76,7 @@ data "aws_iam_policy_document" "code_artifact_assume" {
 
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::631181914621:root"]
+      identifiers = local.ci_config.trusted_oidc_role_arns
     }
 
     actions = ["sts:AssumeRole"]

--- a/infrastructure/terraform/terraform.tfvars.json
+++ b/infrastructure/terraform/terraform.tfvars.json
@@ -1,4 +1,5 @@
 {
+  "identity_account_id": "631181914621",
   "accounts": {
     "development": {
       "account_id": "288342028542",

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -32,3 +32,8 @@ variable "accounts" {
     })
   )
 }
+
+variable "identity_account_id" {
+  description = "Account ID that owns the OIDC serve roles"
+  type        = string
+}


### PR DESCRIPTION
## Purpose

Refactoring serve oidc roles to be more parametrised and not hardcoded - added these in yesterday to fix pipeline error. 



## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
